### PR TITLE
Fix/base64 encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ client.toggle
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test-unit` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/sesame_os2/client.rb
+++ b/lib/sesame_os2/client.rb
@@ -18,10 +18,10 @@ module SesameOs2
       7 => :manualLocked,
       8 => :manualUnlocked,
       9 => :manualElse,
-     10 => :driveLocked,
-     11 => :driveUnlocked,
-     12 => :driveFailed,
-     13 => :bleAdvParameterUpdated,
+      10 => :driveLocked,
+      11 => :driveUnlocked,
+      12 => :driveFailed,
+      13 => :bleAdvParameterUpdated,
     }
 
     COMMAND = {
@@ -85,7 +85,7 @@ module SesameOs2
     end
 
     def encoded64_name
-      Base64.encode64(name)
+      Base64.strict_encode64(name)
     end
 
     def sign

--- a/lib/sesame_os2/ssm.rb
+++ b/lib/sesame_os2/ssm.rb
@@ -32,7 +32,7 @@ module SesameOs2
       unpacked_sk[1..16].pack("C*").unpack("H*").first
     end
 
-    def publick_key
+    def public_key
       unpacked_sk[17..80].pack("C*").unpack("H*").first
     end
 


### PR DESCRIPTION
施錠や解錠などのコマンド実行元情報として、Base64エンコードされた文字列を指定されていますが、
日本語などの文字を入れた場合、改行コードが入ってしまい、sesameアプリで文字化けが発生していました。

`Base64.strict_encode64(name)`を使用し、改行コードが入らないように修正しています。